### PR TITLE
Pass 10 in to toString method to avoid exponent notation

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -41,7 +41,7 @@ export function createNotification(details, customization = {}) {
               : "sending",
           formattedValue: BigNumber(value)
             .div(BigNumber("1000000000000000000"))
-            .toString(),
+            .toString(10),
           preposition: direction === "incoming" ? "from" : "to",
           counterpartyShortened,
           asset

--- a/src/transactions.js
+++ b/src/transactions.js
@@ -113,9 +113,9 @@ export function preflightTransaction(options, emitter, blocknative) {
 
       const txObject = {
         ...txDetails,
-        value: value.toString(),
-        gas: gas && gas.toString(),
-        gasPrice: price && price.toString(),
+        value: value.toString(10),
+        gas: gas && gas.toString(10),
+        gasPrice: price && price.toString(10),
         id
       }
 


### PR DESCRIPTION
closes #16 