### PR TITLE
Simplify Custom Notification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,24 +160,36 @@ You may want to trigger a notification for a custom event that may not be relate
 
 ```javascript
 const notificationObject = {
+  eventCode: "dbUpdate"
   type: "pending",
-  message: "Updating the database with your information",
-  autoDismiss: 4000
+  message: "Updating the database with your information"
 }
 
-const { update, dismiss } = notify.notification(
-  "databaseUpdate",
-  notificationObject
-)
+const { update, dismiss } = notify.notification(notificationObject)
+
+//.... somewhere else in your code
+
+if (dbUpdated) {
+  update({
+    eventCode: "dbUpdateComplete"
+    type: "success",
+    message: "Your info is up to date!"
+  })
+} else {
+  update({
+    eventCode: "dbUpdateSlow"
+    type: "pending",
+    message: "Database update is taking longer than usual, hang in there!"
+  })
+}
 ```
 
-The `notification` function is called with two arguments:
+The `notification` function is called with a notification object with the following parameters:
 
 - `eventCode`: a string which is used to keep track of that event for your analytics dashboard
-- `notificationObject`: a object that defines the notification with the parameters:
-  - `type`: a string that defines the style - ['hint' (gray), 'pending' (yellow), 'success' (green), 'error' (red)]
-  - `message`: a message string that is displayed on the notification
-  - `autoDismiss`: a number in milliseconds before the notification auto dismisses. Defaults to no auto dismissal
+- `type`: a string that defines the style - ['hint' (gray), 'pending' (yellow), 'success' (green), 'error' (red)]
+- `message`: a message string that is displayed on the notification
+- `autoDismiss`: a number in milliseconds before the notification auto dismisses or `false` for no auto dismissal. `success` and `hint` types default to `4000`
 
 Returned from the notification function is an object that has two functions defined on it:
 

--- a/src/components/AutoDismiss.svelte
+++ b/src/components/AutoDismiss.svelte
@@ -4,7 +4,7 @@
 
   if (notification.autoDismiss) {
     setTimeout(() => {
-      notifications.remove(notification);
+      notifications.remove(notification.id);
     }, notification.autoDismiss);
   }
 </script>

--- a/src/index.js
+++ b/src/index.js
@@ -102,16 +102,21 @@ function init(initialize) {
     }
   }
 
-  function notification(eventCode, notificationObject) {
+  function notification(notificationObject) {
     validateNotificationObject(notificationObject)
+
+    let key = 0
 
     const id = uuid()
     const startTime = Date.now()
+    const { eventCode = `customNotification${key++}` } = notificationObject
 
-    const dismiss = () => notifications.remove({ id, eventCode })
+    const dismiss = () => notifications.remove(id)
 
-    function update(eventCode, notificationUpdate) {
+    function update(notificationUpdate) {
       validateNotificationObject(notificationUpdate)
+
+      const { eventCode = `customNotification${key++}` } = notificationUpdate
       createNotification({ id, startTime, eventCode }, notificationUpdate)
 
       return {
@@ -120,7 +125,6 @@ function init(initialize) {
       }
     }
 
-    // create notification
     createNotification({ id, startTime, eventCode }, notificationObject)
 
     return {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -56,7 +56,7 @@ export function createNotification(details, customization = {}) {
     startTime,
     eventCode,
     message: formatter(...formatterOptions),
-    autoDismiss: typeToDismissTimeout(type),
+    autoDismiss: typeToDismissTimeout(customization.type || type),
     ...customization
   }
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -57,8 +57,8 @@ function createNotificationStore(initialState) {
     })
   }
 
-  function remove({ id, eventCode }) {
-    update(store => store.filter(n => n.id !== id || n.eventCode !== eventCode))
+  function remove(id) {
+    update(store => store.filter(n => n.id !== id))
   }
 
   return {

--- a/src/validation.js
+++ b/src/validation.js
@@ -47,6 +47,7 @@ export function validateNotificationObject(notification) {
     notification,
     "notification",
     ow.object.exactShape({
+      eventCode: ow.optional.string,
       type: ow.optional.string.is(validNotificationType),
       message: ow.string,
       autoDismiss: ow.optional.number,

--- a/src/views/Notify.svelte
+++ b/src/views/Notify.svelte
@@ -195,7 +195,7 @@
           {currentTime} />
         <div
           class="bn-notify-custom bn-notify-notification-close"
-          on:click={() => notifications.remove(notification)}>
+          on:click={() => notifications.remove(notification.id)}>
           <CloseIcon />
         </div>
         <AutoDismiss {notification} />


### PR DESCRIPTION
This PR simplifies the API for the `notification` function so that it includes the `eventCode` in the notification object, reducing the arguments for the function to one. It also defaults the `eventCode` to `"customNotification"`.