### PR TITLE
Svelte build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "babel-eslint": "^7.1.1",
-    "babel-plugin-external-helpers": "^6.18.0"
+    "babel-plugin-external-helpers": "^6.18.0",
+    "svelte": "^3.5.4"
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
     "bnc-sdk": "0.2.1",
     "lodash.debounce": "^4.0.8",
     "regenerator-runtime": "^0.13.3",
-    "svelte": "^3.5.4",
     "svelte-i18n": "^1.1.2-beta",
     "uuid": "^3.3.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,16 @@ export default [
       file: "dist/iife/notify.js",
       esModule: false
     },
+    moduleContext: id => {
+      const thisAsWindowForModules = [
+        "node_modules/intl-messageformat/lib/core.js",
+        "node_modules/intl-messageformat/lib/compiler.js"
+      ]
+
+      if (thisAsWindowForModules.some(id_ => id.trimRight().endsWith(id_))) {
+        return "window"
+      }
+    },
     plugins: [
       svelte(),
       json(),
@@ -38,22 +48,26 @@ export default [
       "bignumber.js",
       "bnc-sdk",
       "lodash.debounce",
-      "svelte-i18n",
       "uuid/v4",
-      "svelte",
-      "svelte/store",
-      "svelte/internal",
-      "svelte/transition",
-      "svelte/easing",
-      "svelte/animate",
       "regenerator-runtime/runtime"
     ],
     plugins: [
       svelte(),
       json(),
+      resolve(),
       commonjs(),
       babel({ exclude: "node_modules/**" })
     ],
+    moduleContext: id => {
+      const thisAsWindowForModules = [
+        "node_modules/intl-messageformat/lib/core.js",
+        "node_modules/intl-messageformat/lib/compiler.js"
+      ]
+
+      if (thisAsWindowForModules.some(id_ => id.trimRight().endsWith(id_))) {
+        return "window"
+      }
+    },
     output: [
       {
         dir: "dist/esm",


### PR DESCRIPTION
This PR cleans up some of the build settings by moving `svelte` to a dev dependency and updating the rollup config to remove the `svelte` libraries as external. There were some problems in some build environments with `svelte-i18n` due to it being set as external in the rollup config. Because it is a `svelte` library it needs to be compiled at build time and included in the bundle, so it has been removed from the `external` parameter in the `rollup.config.json`.