### PR TITLE
Fix: Type exports

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -25,7 +25,7 @@ import type {
   LocaleMessages
 } from './interfaces'
 
-export type {
+export {
   InitOptions,
   TransactionHandler,
   TransactionEvent,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "resolveJsonModule": true,
     "target": "ESNEXT",
     "declaration": true,
-    "declarationDir": "dist/types"
+    "declarationDir": "dist/types",
+    "isolatedModules": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules/*", "dist/*"]


### PR DESCRIPTION
This PR fixes a previous regression from switching over to the new svelte-typescript template. Setting the `isolatedModules` to false allows for exporting without the `type` prefix which allows the exports to be used as values if needed.