### PR TITLE
Enhancement: Optional dappId

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,8 +5,6 @@ import type {
 
 export interface InitOptions extends ConfigOptions {
   dappId?: string
-  system?: System
-  networkId?: number
   transactionHandler?: TransactionHandler
   name?: string
   apiUrl?: string

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,8 +4,9 @@ import type {
 } from 'bnc-sdk/dist/types/src/interfaces'
 
 export interface InitOptions extends ConfigOptions {
-  dappId: string
-  networkId: number
+  dappId?: string
+  system?: System
+  networkId?: number
   transactionHandler?: TransactionHandler
   name?: string
   apiUrl?: string
@@ -106,9 +107,9 @@ export interface ContractObject {
 
 export interface AppStore {
   version: string
-  dappId: string
+  dappId?: string
   name?: string
-  networkId: number
+  networkId?: number
   nodeSynced: boolean
   mobilePosition: 'bottom' | 'top'
   desktopPosition: 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight'

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -84,14 +84,18 @@ function init(options: InitOptions): API {
     transactionHandlers.push(transactionHandler)
   }
 
-  let blocknative = new BlocknativeSdk({
-    dappId,
-    networkId,
-    transactionHandlers,
-    name: name || 'Notify',
-    apiUrl,
-    system
-  })
+  let blocknative
+
+  if (dappId) {
+    blocknative = new BlocknativeSdk({
+      dappId,
+      networkId,
+      transactionHandlers,
+      name: name || 'Notify',
+      apiUrl,
+      system
+    })
+  }
 
   // save config to app store
   app.update((store: AppStore) => ({
@@ -134,6 +138,12 @@ function init(options: InitOptions): API {
   function account(
     address: string
   ): { details: { address: string }; emitter: Emitter } | never {
+    if (!blocknative) {
+      throw new Error(
+        'A dappId needs to be passed in when intializing Notify to use the account function'
+      )
+    }
+
     try {
       const result = blocknative.account(address)
       return result
@@ -143,6 +153,12 @@ function init(options: InitOptions): API {
   }
 
   function hash(hash: string, id?: string) {
+    if (!blocknative) {
+      throw new Error(
+        'A dappId needs to be passed in when intializing Notify to use the hash function'
+      )
+    }
+
     try {
       const result = blocknative.transaction(hash, id)
       return result
@@ -154,6 +170,12 @@ function init(options: InitOptions): API {
   function transaction(
     options: TransactionOptions
   ): { result: Promise<string>; emitter: Emitter } {
+    if (!blocknative) {
+      throw new Error(
+        'A dappId needs to be passed in when intializing Notify to use the transaction function'
+      )
+    }
+
     validateTransactionOptions(options)
 
     const emitter = createEmitter()
@@ -169,6 +191,12 @@ function init(options: InitOptions): API {
   }
 
   function unsubscribe(addressOrHash: string) {
+    if (!blocknative) {
+      throw new Error(
+        'A dappId needs to be passed in when intializing Notify to use the unsubscribe function'
+      )
+    }
+
     blocknative.unsubscribe(addressOrHash)
   }
 
@@ -232,6 +260,12 @@ function init(options: InitOptions): API {
       (newNetworkId && newNetworkId !== networkId) ||
       (newSystem && newSystem !== system)
     ) {
+      if (!blocknative) {
+        throw new Error(
+          'A dappId needs to be passed in when intializing Notify to be able to connect to a system and network'
+        )
+      }
+
       // close existing SDK connection
       blocknative.destroy()
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -100,16 +100,29 @@ export function validateInit(init: InitOptions): void {
     ...otherParams
   } = init
 
-  validateType({ name: 'dappId', value: dappId, type: 'string' })
+  validateType({
+    name: 'dappId',
+    value: dappId,
+    type: 'string',
+    optional: true
+  })
 
   validateType({
     name: 'system',
     value: system,
     type: 'string',
+    // defaults to ethereum so optional
     optional: true
   })
 
-  validateType({ name: 'networkId', value: networkId, type: 'number' })
+  // if no dappId provided then optional, otherwise required
+  validateType({
+    name: 'networkId (if dappId provided)',
+    value: networkId,
+    type: 'number',
+    optional: !dappId
+  })
+
   validateType({ name: 'name', value: name, type: 'string', optional: true })
 
   validateType({


### PR DESCRIPTION
This PR makes changes so that Notify can also be used as Notification UI library without needing to connect to the Blocknative server infrastructure.

To do this it:

- Makes the `dappId` optional
- If no `dappId` then it will not initialize the Blocknative SDK
- If no `dappId` then the `networkId` also becomes optional in validation function
- If no initialized Blocknative SDK instance is available, then `account`, `hash`, `transaction`, `unsubscribe` and `config`(when called with a `system` or `networkId`) functions will all throw an error to let the dev know that a `dappId` is required upon initialization for these functions to work.

- Docs need to be updated to reflect these changes.