### PR TITLE
Feature: Notification link

### DIFF
--- a/src/components/NotificationContent.svelte
+++ b/src/components/NotificationContent.svelte
@@ -53,8 +53,7 @@
     justify-content: center;
     font-size: inherit;
     font-family: inherit;
-    margin-left: 0.75em;
-    max-width: 78%;
+    margin: 0 1.5rem 0 0.75rem;
   }
 
   /* .bn-notify-notification-info-meta */

--- a/src/components/TypeIcon.svelte
+++ b/src/components/TypeIcon.svelte
@@ -9,7 +9,6 @@
     height: 100%;
     font-size: inherit;
     font-family: inherit;
-    width: 1.5em;
   }
 </style>
 
@@ -17,6 +16,7 @@
   class="bn-notify-custom bn-notify-notification-status-icon {$app.name ? `bn-notify-${$app.name}` : ''}">
   {#if type === 'hint'}
     <svg
+      width="18px"
       viewBox="0 0 190 190"
       xmlns="http://www.w3.org/2000/svg"
       id="el_DHAskxC2T">
@@ -265,6 +265,7 @@
 
   {#if type === 'pending'}
     <svg
+      width="18px"
       viewBox="0 0 190 190"
       xmlns="http://www.w3.org/2000/svg"
       id="el_XWLVvD_rP">
@@ -404,6 +405,7 @@
 
   {#if type === 'success'}
     <svg
+      width="18px"
       viewBox="0 0 185 168"
       xmlns="http://www.w3.org/2000/svg"
       id="el_3OA8Szq_A">
@@ -481,6 +483,7 @@
 
   {#if type === 'error'}
     <svg
+      width="18px"
       viewBox="0 0 178 178"
       xmlns="http://www.w3.org/2000/svg"
       id="el_bYTVKD04y">

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -79,6 +79,7 @@ export interface CustomNotificationObject {
   autoDismiss?: number
   onclick?: (event: any) => void
   eventCode?: string
+  link?: string
 }
 
 export interface BitcoinInputOutput {

--- a/src/views/Notify.svelte
+++ b/src/views/Notify.svelte
@@ -101,7 +101,7 @@
     padding: 0 0.75em;
     margin: 0;
     list-style-type: none;
-    width: 20em;
+    width: 18rem;
     bottom: 0;
     right: 0;
     font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
@@ -163,6 +163,12 @@
     font-size: inherit;
     font-family: inherit;
   }
+
+  a {
+    display: flex;
+    text-decoration: none;
+    color: inherit;
+  }
 </style>
 
 {#if $notifications.length > 0}
@@ -180,8 +186,19 @@
         {$app.name ? `bn-notify-${$app.name}` : ''}"
         in:fly={{ duration: 1200, delay: 300, x, y, easing: elasticOut }}
         out:fly={{ duration: 400, x, y, easing: quintIn }}>
-        <TypeIcon type={notification.type} />
-        <NotificationContent {notification} />
+        {#if notification.link}
+          <a
+            class="bn-notify-notification-link"
+            href={notification.link}
+            target="_blank"
+            rel="noreferrer noopener">
+            <TypeIcon type={notification.type} />
+            <NotificationContent {notification} />
+          </a>
+        {:else}
+          <TypeIcon type={notification.type} />
+          <NotificationContent {notification} />
+        {/if}
         <div
           class="bn-notify-custom bn-notify-notification-close {$app.name ? `bn-notify-${$app.name}` : ''}"
           on:click|stopPropagation={() => notifications.remove(notification.id, notification.eventCode)}>


### PR DESCRIPTION
This PR adds an optional `link` property to the custom notification object, allowing for a simple URL to be returned from the emitter to wrap a notification in a link as requested in #172 