### PR TITLE
1.5.1-0.0.1: [feature] - Filter Simulation Pending events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.5.1",
+  "version": "1.5.1-0.0.1",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
-    "bnc-sdk": "^2.1.5",
+    "bnc-sdk": "^3.3.0",
     "lodash.debounce": "^4.0.8",
     "regenerator-runtime": "^0.13.3",
     "uuid": "^3.3.3"

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -96,6 +96,12 @@ function init(options: InitOptions): API {
       apiUrl,
       system
     })
+
+    // filter out pending simulation events
+    blocknative.configuration({
+      scope: 'global',
+      filters: [{ status: 'pending-simulation', _not: true }]
+    })
   }
 
   // save config to app store

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,12 +1274,13 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bnc-sdk@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-2.1.5.tgz#7f40bcf98eb0238882f5436c0e860e60be2867c0"
-  integrity sha512-rtwOGKjal1LQyYrdESdOfCK5L2ocS3tjoWtNacm3rkb+xjDusVnUpF/NgudJpCnv3Mwu9YDWjsLKIPKjwbJL7A==
+bnc-sdk@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-3.3.0.tgz#a690abe7570a43745936a308006fa52c1d806017"
+  integrity sha512-5MaL1uhKQn3dY3uBfW5HujXCS988/vMX0MY7LtkDjmA396a3DSbGcGySsHVsJZCBVopUupl0geI5w28+p8PG9g==
   dependencies:
     crypto-es "^1.2.2"
+    rxjs "^6.6.3"
     sturdy-websocket "^0.1.12"
 
 brace-expansion@^1.1.7:
@@ -3054,6 +3055,13 @@ rxjs@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
   integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.3:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This PR filters out all transaction events with a status of `pending-simulation` as they are likely not useful in the context of notifications. Filtering out these events will prevent simulation rate limit errors.