### PR TITLE
1.6.1-0.1.1: [enhancement] - Error Handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.6.1",
+  "version": "1.6.1-0.1.1",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,7 +8,10 @@ export interface InitOptions extends ConfigOptions {
   transactionHandler?: TransactionHandler
   name?: string
   apiUrl?: string
+  onerror?: ErrorHandler
 }
+
+export type ErrorHandler = (error: { message: string }) => void
 
 export interface TransactionHandler {
   (transaction: TransactionEvent): void
@@ -115,6 +118,7 @@ export interface AppStore {
   name?: string
   networkId?: number
   nodeSynced: boolean
+  onerror?: ErrorHandler
   mobilePosition: 'bottom' | 'top'
   desktopPosition: 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight'
   darkMode: boolean

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,7 @@
 import type {
   BitcoinTransactionLog,
-  EthereumTransactionLog
+  EthereumTransactionLog,
+  SDKError
 } from 'bnc-sdk/dist/types/src/interfaces'
 
 export interface InitOptions extends ConfigOptions {
@@ -11,7 +12,7 @@ export interface InitOptions extends ConfigOptions {
   onerror?: ErrorHandler
 }
 
-export type ErrorHandler = (error: { message: string }) => void
+export type ErrorHandler = (error: SDKError) => void
 
 export interface TransactionHandler {
   (transaction: TransactionEvent): void

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -77,7 +77,7 @@ function init(options: InitOptions): API {
   validateInit(options)
 
   const { system, transactionHandler, apiUrl, ...appOptions } = options
-  const { dappId, networkId, name, clientLocale } = appOptions
+  const { dappId, networkId, name, clientLocale, onerror } = appOptions
 
   const transactionHandlers: TransactionHandler[] = [handleTransactionEvent]
 
@@ -91,7 +91,7 @@ function init(options: InitOptions): API {
     blocknative = new BlocknativeSdk({
       dappId,
       networkId,
-      onerror: appOptions.onerror,
+      onerror,
       transactionHandlers,
       name: name || 'Notify',
       apiUrl,

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -91,6 +91,7 @@ function init(options: InitOptions): API {
     blocknative = new BlocknativeSdk({
       dappId,
       networkId,
+      onerror: appOptions.onerror,
       transactionHandlers,
       name: name || 'Notify',
       apiUrl,
@@ -151,12 +152,8 @@ function init(options: InitOptions): API {
       )
     }
 
-    try {
-      const result = blocknative.account(address)
-      return result
-    } catch (error) {
-      throw new Error(error)
-    }
+    const result = blocknative.account(address)
+    return result
   }
 
   function hash(hash: string, id?: string) {
@@ -166,12 +163,8 @@ function init(options: InitOptions): API {
       )
     }
 
-    try {
-      const result = blocknative.transaction(hash, id)
-      return result
-    } catch (error) {
-      throw new Error(error)
-    }
+    const result = blocknative.transaction(hash, id)
+    return result
   }
 
   function transaction(
@@ -188,7 +181,11 @@ function init(options: InitOptions): API {
     const emitter = createEmitter()
 
     const result = preflightTransaction(blocknative, options, emitter).catch(
-      err => err
+      err => {
+        const { onerror } = get(app)
+        onerror && onerror(err)
+        return err
+      }
     )
 
     return {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -99,10 +99,14 @@ function init(options: InitOptions): API {
     })
 
     // filter out pending simulation events
-    blocknative.configuration({
-      scope: 'global',
-      filters: [{ status: 'pending-simulation', _not: true }]
-    })
+    blocknative
+      .configuration({
+        scope: 'global',
+        filters: [{ status: 'pending-simulation', _not: true }]
+      })
+      .catch(() => {
+        // swallow server timeout response error as we are not waiting on it
+      })
   }
 
   // save config to app store

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -11,6 +11,7 @@ const validInitKeys = [
   'system',
   'transactionHandler',
   'name',
+  'onerror',
   'mobilePosition',
   'desktopPosition',
   'darkMode',
@@ -97,6 +98,7 @@ export function validateInit(init: InitOptions): void {
     transactionHandler,
     name,
     apiUrl,
+    onerror,
     ...otherParams
   } = init
 
@@ -135,6 +137,13 @@ export function validateInit(init: InitOptions): void {
   validateType({
     name: 'transactionHandler',
     value: transactionHandler,
+    type: 'function',
+    optional: true
+  })
+
+  validateType({
+    name: 'onerror',
+    value: onerror,
     type: 'function',
     optional: true
   })


### PR DESCRIPTION
This PR adds a new parameter to the initialization object: `onerror`. This will get passed on to the SDK so that all errors that return from the server will get passed on to the function that is added on init. This will allow devs to handle rate limit errors in particular, allowing them to decide whether to remove notifications or add a custom notification indicating the error.