### PR TITLE
1.9.3-0.0.1 : [update] - SDK ver update and new Type2 Gas Props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.9.3",
+  "version": "1.9.3-0.0.1",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
-    "bnc-sdk": "4.0.0",
+    "bnc-sdk": "4.1.0",
     "lodash.debounce": "^4.0.8",
     "regenerator-runtime": "^0.13.3",
     "uuid": "^3.3.3"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,6 +71,10 @@ export interface TransactionData {
   system?: string
   inputs?: BitcoinInputOutput[]
   outputs?: BitcoinInputOutput[]
+  baseFeePerGasGwei?: number
+  maxPriorityFeePerGasGwei?: number
+  maxFeePerGasGwei?: number
+  gasPriceGwei?: number
 }
 
 export type NotificationType = 'pending' | 'success' | 'error' | 'hint'


### PR DESCRIPTION
### Description
SDK ver update to 4.1.0 to handle Fantom and new Type2 Gas Props

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
