### PR TITLE
Update bnc-sdk to 4.1.0, allow minor release updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
-    "bnc-sdk": "4.0.0",
+    "bnc-sdk": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "regenerator-runtime": "^0.13.3",
     "uuid": "^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,10 +2175,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
-bnc-sdk@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.0.0.tgz#0bf8af5c7c3fab7912912431e1af0e48e01b608b"
-  integrity sha512-ob0GP1dS2yGvV+2hpJgpmrJeen0W68K4jsfjikbuL7ogBAVaQaWbPAzKw2w9tgq9BUM96CR43UpAobSyTZDx7g==
+bnc-sdk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.1.0.tgz#b7bd280a2e0d218b003ed9d227bcc36593bd6f04"
+  integrity sha512-gbW5wRLPB7HDzXof5VrkFSDoyfuD2O9K8dOTRQl2OE/HAj3/epKyccQDtWNLNih7t234VM/sv9t6nxqRnNRJmQ==
   dependencies:
     crypto-es "^1.2.2"
     rxjs "^6.6.3"


### PR DESCRIPTION
### Description
This PR updates `bnc-sdk` to 4.1.0, and also relaxes version constraint to allow minor version upgrades in the future.

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
