### PR TITLE
Add link validation to validateNotificationObject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.9.4",
+  "version": "1.9.4-0.0.1",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -27,7 +27,8 @@ const validNotificationKeys = [
   'type',
   'message',
   'autoDismiss',
-  'onclick'
+  'onclick',
+  'link'
 ]
 
 const validTransactionKeys = [
@@ -277,6 +278,7 @@ export function validateNotificationObject(
     message,
     autoDismiss,
     onclick,
+    link,
     ...otherParams
   } = notification
 
@@ -314,6 +316,13 @@ export function validateNotificationObject(
     name: 'onclick',
     value: onclick,
     type: 'function',
+    optional: true
+  })
+
+  validateType({
+    name: 'link',
+    value: link,
+    type: 'string',
     optional: true
   })
 }


### PR DESCRIPTION
### Description
As exported in `interfaces.ts`, `CustomNotificationObject` was suppose to support `link` parameter. The fact is that `API::notification(CustomNotificationObject)` doesn't treat `link` as a valid parameter and do validation for it, instead, an exception suggested that `link` is invalid parameter.

This change to to add `link` parameter` into the validation.

Updated the version to `1.9.4-0.0.1`.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
