### PR TITLE
1.9.5 - Release Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.9.4-0.0.1",
+  "version": "1.9.5",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
### Description
This release includes an update to the validation to allow for the `link` property to be passed in custom notifications as well as a dependabot version bump

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
