### PR TITLE
Release 1.9.6 (develop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.9.5-0.0.1",
+  "version": "1.9.6",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
### Description
Fix validation for `txStuck`

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
