### PR TITLE
Update: SDK Drop Chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.9.6",
+  "version": "1.9.6-0.0.1",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
-    "bnc-sdk": "4.1.0",
+    "bnc-sdk": "4.6.3",
     "lodash.debounce": "^4.0.8",
     "regenerator-runtime": "^0.13.3",
     "uuid": "^3.3.3"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,8 +2,9 @@ import type {
   BitcoinTransactionLog,
   EthereumTransactionLog,
   SDKError,
-  TransactionHandler
-} from 'bnc-sdk/dist/types/src/interfaces'
+  TransactionHandler,
+  System
+} from 'bnc-sdk'
 
 export interface InitOptions extends ConfigOptions {
   dappId?: string
@@ -19,8 +20,6 @@ export interface TransactionEvent {
   emitterResult: void | boolean | CustomNotificationObject
   transaction: TransactionData
 }
-
-export type System = 'bitcoin' | 'ethereum'
 
 export type TransactionEventCode =
   | 'txSent'

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,6 +1,6 @@
 import 'regenerator-runtime/runtime'
 import BlocknativeSdk from 'bnc-sdk'
-import type { TransactionHandler } from 'bnc-sdk/dist/types/src/interfaces'
+import type { TransactionHandler } from 'bnc-sdk'
 import { get } from 'svelte/store'
 
 import uuid from 'uuid/v4'
@@ -27,7 +27,6 @@ import type {
 export {
   InitOptions,
   TransactionEvent,
-  System,
   TransactionEventCode,
   TransactionData,
   NotificationType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,12 +2175,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
-bnc-sdk@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.1.0.tgz#b7bd280a2e0d218b003ed9d227bcc36593bd6f04"
-  integrity sha512-gbW5wRLPB7HDzXof5VrkFSDoyfuD2O9K8dOTRQl2OE/HAj3/epKyccQDtWNLNih7t234VM/sv9t6nxqRnNRJmQ==
+bnc-sdk@4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.6.3.tgz#c852f091a5e84bb77864543b0775b35ebdbb1724"
+  integrity sha512-rva+LyJuAm+U6xwZYqlsDxKaMy3EpHBqkOL93UDih7iwXDYnUr87n27pnGCw3B8xRBeRhCBC/VZMuzRFeea/Hw==
   dependencies:
     crypto-es "^1.2.2"
+    nanoid "^3.3.1"
     rxjs "^6.6.3"
     sturdy-websocket "^0.1.12"
 
@@ -3509,6 +3510,11 @@ ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nanoid@^3.3.1:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
### Description
Updates to the latest SDK which has deprecated unsuppported chains `kovan`, `bsc-main`, Bitcoin `main` and `testnet` and `fantom`

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
