### PR TITLE
1.9.7-0.0.1 - Update to Latest SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-notify",
-  "version": "1.9.7",
+  "version": "1.9.7-0.0.1",
   "description": "Show web3 users realtime transaction notifications",
   "keywords": [
     "ethereum",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
-    "bnc-sdk": "4.6.3",
+    "bnc-sdk": "^4.6.4",
     "lodash.debounce": "^4.0.8",
     "regenerator-runtime": "^0.13.3",
     "uuid": "^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,10 +2175,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
-bnc-sdk@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.6.3.tgz#c852f091a5e84bb77864543b0775b35ebdbb1724"
-  integrity sha512-rva+LyJuAm+U6xwZYqlsDxKaMy3EpHBqkOL93UDih7iwXDYnUr87n27pnGCw3B8xRBeRhCBC/VZMuzRFeea/Hw==
+bnc-sdk@^4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.6.4.tgz#2fd2f9996b4b4c262a43b91b70e9af8ceae67fba"
+  integrity sha512-qv310dYLFSIwDhFFFmwPHXpoLFzyneK0f2YFji1ISaFH36hkOVLyD94vx2G5uT66RljxMHUQ8GushqraGKM+bg==
   dependencies:
     crypto-es "^1.2.2"
     nanoid "^3.3.1"


### PR DESCRIPTION
### Description
Updates to the latest Blocknative SDK that deprecates Rinkeby and Ropsten

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
